### PR TITLE
I corrected a SyntaxError in `src/testpkg/missing_colon.py` by adding…

### DIFF
--- a/src/testpkg/missing_colon.py
+++ b/src/testpkg/missing_colon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-def division(a: float, b: float) -> float
+def division(a: float, b: float) -> float:
     return a/b
 
 

--- a/tests/missing_colon.py
+++ b/tests/missing_colon.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
+import pytest
+from src.testpkg.missing_colon import division
 
+def test_division_success():
+    assert division(10, 2) == 5
+    assert division(123, 15) == 8.2
 
-def division(a: float, b: float) -> float
-    return a/b
-
-
-if __name__ == "__main__":
-    print(division(123, 15))
-
+def test_division_by_zero():
+    with pytest.raises(ZeroDivisionError):
+        division(23, 0)


### PR DESCRIPTION
… a missing colon at the end of the `division` function definition.

I also added test cases in `tests/missing_colon.py`:
- `test_division_success`: Ensures normal division works as expected.
- `test_division_by_zero`: Verifies that attempting to divide by zero raises a `ZeroDivisionError`.